### PR TITLE
fish weight metadata in inventory

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -167,7 +167,7 @@ AddEventHandler('rsg-fishing:FishToInventory', function(fishModel, weight)
     local fish = fishEntity[fishModel]
     local fish_name = fishNames[fishModel]
     local fish_weight = string.format('%.2f%%', (weight * 54.25)):gsub('%%', '')
-    Player.Functions.AddItem(fish, 1)
+    Player.Functions.AddItem(fish, 1, nil, {weight = fish_weight})
     TriggerClientEvent('rsg-inventory:client:ItemBox', src, RSGCore.Shared.Items[fish], 'add', 1)
     TriggerClientEvent('ox_lib:notify', src, {title = locale('sv_you_got_fish_name')..' '..fish_name, type = 'success', duration = 5000 })
     TriggerEvent('rsg-log:server:CreateLog', 'fishing', locale('sv_discord_b'), 'green', Player.PlayerData.firstname..' '..Player.PlayerData.lastname..' '.. locale('sv_discord_c') ..' '.. fish_weight..'KG '..fish_name)


### PR DESCRIPTION
I added the "Weight" metadata since it did not appear in the inventory.

![fish](https://github.com/user-attachments/assets/dc322ef4-ff84-4312-8748-84cd9d840984)
